### PR TITLE
fixed null being assigned above log

### DIFF
--- a/src/server.c
+++ b/src/server.c
@@ -104,7 +104,6 @@ int main() {
 
         memset(&http_response_array[0], 0, sizeof(http_response_array));
         memset(&socket_response[0], 0, sizeof(socket_response));
-        open_path = NULL;
 
         ///////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Relates to: https://github.com/csmets/http-server/issues/3